### PR TITLE
Update references to init-db script in setup

### DIFF
--- a/engager/setup.html
+++ b/engager/setup.html
@@ -115,7 +115,7 @@
               </li>
               <li>
                 <p>Initialize the database:</p>
-                <pre><code class="language-text" data-lang="text">heroku run bin/init-db</code></pre>
+                <pre><code class="language-text" data-lang="text">heroku run init-db</code></pre>
               </li>
           </ol>
           <h2>Deploying UI to Heroku using the Command Line</h2>
@@ -159,7 +159,7 @@
               </li>
               <li>
                 <p>Initialize the database:</p>
-                <pre><code class="language-text" data-lang="text">./bin/init-db</code></pre>
+                <pre><code class="language-text" data-lang="text">npm run init-db</code></pre>
               </li>
               <li>
                 <p>Start the API:</p>


### PR DESCRIPTION
`./bin/init-db` -> `npm run init-db`
`heroku run bin/init-db` -> `heroku run init-db`
fixes #1 
